### PR TITLE
Update FMOD path per platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,12 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(REAPER_SDK_DIR "${CMAKE_SOURCE_DIR}/reaper-sdk")
 set(REAPER_REAIMGUI_DIR "${CMAKE_SOURCE_DIR}/ReaImGui")
 
-# Path to FMOD API
-set(FMOD_API_DIR "${CMAKE_SOURCE_DIR}/fmod")
+# Path to FMOD API - select the subdirectory for the current platform
+if(APPLE)
+    set(FMOD_API_DIR "${CMAKE_SOURCE_DIR}/fmod/Mac")
+elseif(WIN32)
+    set(FMOD_API_DIR "${CMAKE_SOURCE_DIR}/fmod/Windows")
+endif()
 
 # Path to tinyfiledialogs
 set(TINYFILEDIALOGS_DIR "${CMAKE_SOURCE_DIR}/tinyfiledialogs")


### PR DESCRIPTION
## Summary
- pick FMOD API directory based on OS
- keep include/link paths using this variable

## Testing
- `cmake -S . -B /tmp/ReaMOD-build`
- `cmake --build /tmp/ReaMOD-build` *(fails: fmod_studio.hpp not found)*

------
https://chatgpt.com/codex/tasks/task_e_688281bbef1c8331b046b78cd1f08c4a