### PR TITLE
Adjust FMOD bank directory remove button placement

### DIFF
--- a/src/ReaMOD.cpp
+++ b/src/ReaMOD.cpp
@@ -3276,22 +3276,26 @@ void RenderGUI() {
                     dirError.clear();
                     isDirectory = fs::is_directory(displayPath, dirError);
                 }
-                if (!directoryExists || dirError || !isDirectory) {
+                bool isValidDirectory = directoryExists && !dirError && isDirectory;
+                if (!isValidDirectory) {
                     displayPath += " (missing)";
-                    ImGui::TextColored(reaMOD_Main_ImGui_Context, orange, displayPath.c_str());
-                } else {
-                    ReaMODText(reaMOD_Main_ImGui_Context, displayPath.c_str(), reaMODMediumFont);
                 }
 
                 std::string removeLabel = "Remove##BankDir" + std::to_string(i);
                 std::string upLabel = "Up##BankDir" + std::to_string(i);
                 std::string downLabel = "Down##BankDir" + std::to_string(i);
 
-                ImGui::SameLine(reaMOD_Main_ImGui_Context);
                 if (StyledButton(reaMOD_Main_ImGui_Context, removeLabel)) {
                     customBankDirectories.erase(customBankDirectories.begin() + i);
                     directoryListChanged = true;
                     break;
+                }
+
+                ImGui::SameLine(reaMOD_Main_ImGui_Context);
+                if (!isValidDirectory) {
+                    ImGui::TextColored(reaMOD_Main_ImGui_Context, orange, displayPath.c_str());
+                } else {
+                    ReaMODText(reaMOD_Main_ImGui_Context, displayPath.c_str(), reaMODMediumFont);
                 }
 
                 if (i > 0) {


### PR DESCRIPTION
## Summary
- move the remove button for FMOD bank directories ahead of the path display so it appears on the left
- keep highlighting for missing directories while reusing the existing up/down controls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68def0708af8833197ef39989c2bdda9