### PR TITLE
Declare GetEventLengthSeconds prototype

### DIFF
--- a/src/ReaMOD.cpp
+++ b/src/ReaMOD.cpp
@@ -122,6 +122,7 @@ FMOD::Studio::System* fmod_system = nullptr;
 
 void RefreshBankFiles();
 void SynchronizeLoadedBanks();
+double GetEventLengthSeconds(const std::string& eventPath);
 
 // Define the ParameterInfo struct
 struct ParameterInfo {


### PR DESCRIPTION
## Summary
- declare GetEventLengthSeconds before its first use so the compiler sees it

## Testing
- cmake --build build *(fails: missing third-party FMOD headers in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df39884a2c8331bcaa080f2b785dbb