### PR TITLE
Prevent crashes when closing the ReaMOD window

### DIFF
--- a/src/ReaMOD.cpp
+++ b/src/ReaMOD.cpp
@@ -3365,7 +3365,20 @@ void RemoveTask(int taskId) {
 
 // Timer function
 void OnTimer() {
-    for (auto& [taskId, task] : taskMap) {
+    // Copy the tasks that should be executed before running them. This prevents
+    // iterator invalidation when a task removes itself (or another task) while
+    // the timer is iterating over the task map. Without this safeguard, closing
+    // the ReaMOD window from within its RenderGUI task would erase the task from
+    // taskMap while the range-based for loop was still referencing the erased
+    // element, leading to a crash.
+    std::vector<std::function<void()>> tasksToRun;
+    tasksToRun.reserve(taskMap.size());
+
+    for (const auto& [taskId, task] : taskMap) {
+        tasksToRun.push_back(task);
+    }
+
+    for (auto& task : tasksToRun) {
         task();
     }
 }


### PR DESCRIPTION
## Summary
- avoid iterator invalidation in the timer loop by copying scheduled tasks before executing them
- this keeps task removal during execution (such as when closing the ReaMOD window) from crashing Reaper

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e317f7561883318b694462517e2f3c