### PR TITLE
Add safety check before rendering event search window

### DIFF
--- a/src/ReaMOD.cpp
+++ b/src/ReaMOD.cpp
@@ -3111,6 +3111,11 @@ bool StyledButton(ImGui_Context* ctx, const std::string& label) {
 
 void RenderEventSearchWindow() {
 
+    // Early exit if the context is not available
+    if (!reaMOD_Main_ImGui_Context) {
+        return;
+    }
+
     // Check if the search window should be open
     if (!searchFmodEventWindowOpen) {
         return;


### PR DESCRIPTION
## Summary
- add an early exit in `RenderEventSearchWindow` to guard against a missing ImGui context

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e9de355aa083319bcaab7bb1cf6812