### PR TITLE
Improved jsfx setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@
 # fmod/**
 build/CMakeFiles/CMakeConfigureLog.yaml
 build/reaper_ReaMOD_Plugin.dylib
+/build

--- a/src/ReaMOD.cpp
+++ b/src/ReaMOD.cpp
@@ -135,7 +135,15 @@ struct ParameterInfo {
     float maxValue;
     float defaultValue;
     float currentValue;
+
+    // NEW:
+    unsigned int flags = 0;               // FMOD_STUDIO_PARAMETER_FLAGS
+    std::vector<std::string> labels;      // for labeled params
+
+    bool isDiscrete() const { return (flags & FMOD_STUDIO_PARAMETER_DISCRETE) != 0; }
+    bool isLabeled()  const { return (flags & FMOD_STUDIO_PARAMETER_LABELED)  != 0; }
 };
+
 
 struct GlobalParameter {
     std::string name;
@@ -1287,20 +1295,44 @@ bool UpdateSelectedEventParameters(const std::string& eventPath) {
     for (int i = 0; i < paramCount; ++i) {
         FMOD_STUDIO_PARAMETER_DESCRIPTION paramDesc;
         result = eventDesc->getParameterDescriptionByIndex(i, &paramDesc);
-        if (result != FMOD_OK) {
-            DebugMsg("Failed to get parameter description by index %d for event: %s\n", i, eventPath.c_str());
-            continue;
-        }
-
+        if (result != FMOD_OK) { /* ... continue; */ }
+        
         ParameterInfo paramInfo;
-        paramInfo.name = paramDesc.name;
-        paramInfo.id = paramDesc.id;
-        paramInfo.minValue = paramDesc.minimum;
-        paramInfo.maxValue = paramDesc.maximum;
+        paramInfo.name         = paramDesc.name;
+        paramInfo.id           = paramDesc.id;
+        paramInfo.minValue     = paramDesc.minimum;
+        paramInfo.maxValue     = paramDesc.maximum;
         paramInfo.defaultValue = paramDesc.defaultvalue;
-        paramInfo.currentValue = paramDesc.defaultvalue; // Initialize to default value
+        paramInfo.currentValue = paramDesc.defaultvalue;
+        paramInfo.flags        = paramDesc.flags;
+        
+        // If labeled, pull label strings for each integer index in range:
+        if ((paramInfo.flags & FMOD_STUDIO_PARAMETER_LABELED) != 0) {
+            const int first = (int)std::round(paramInfo.minValue);
+            const int last  = (int)std::round(paramInfo.maxValue);
+            for (int li = first; li <= last; ++li) {
+                char buf[256] = {};
+                // Prefer the API that exists in your FMOD version:
+                // - getParameterLabelByIndex(paramIndex, labelIndex, buf, buflen)
+                // - OR getParameterLabelByName(paramDesc.name, labelIndex, ...)
+                // - OR getParameterLabelByID(paramDesc.id, labelIndex, ...)
+                //
+                // Replace the call below with the variant you have:
+                int retrieved = 0;
+                result = eventDesc->getParameterLabelByIndex(i, li - first, buf, sizeof(buf), &retrieved);
 
-        selectedEventParameters.push_back(paramInfo);
+        
+                if (result == FMOD_OK && buf[0] != '\0') {
+                    paramInfo.labels.emplace_back(buf);
+                } else {
+                    // Fallback: if label missing, insert the numeric index as text
+                    paramInfo.labels.emplace_back(std::to_string(li));
+                }
+            }
+        }
+        
+        selectedEventParameters.push_back(std::move(paramInfo));
+        
     }
 
     // Cache the parameters
@@ -4374,6 +4406,59 @@ bool CreateDirectoryIfNotExists(const std::string& directoryPath) {
     return true; // Directory already exists
 }
 
+static inline std::string FmtFloat(double v) {
+    char buf[64];
+    std::snprintf(buf, sizeof(buf), "%.6f", v);
+    std::string s(buf);
+    while (!s.empty() && s.back() == '0') s.pop_back();
+    if (!s.empty() && s.back() == '.') s.pop_back();
+    if (s.empty()) s = "0";
+    return s;
+}
+
+static inline std::string SanitizeForJSFXName(const std::string& s) {
+    std::string out; out.reserve(s.size());
+    for (char c : s) {
+        if (c == '\n' || c == '\r' || c == '{' || c == '}' || c == '<' || c == '>') out.push_back(' ');
+        else out.push_back(c);
+    }
+    return out;
+}
+
+static inline std::string SanitizeLabel(const std::string& s) {
+    std::string out; out.reserve(s.size());
+    for (char c : s) {
+        if (c == ',' || c == '{' || c == '}' || c == '<' || c == '>') out.push_back(' ');
+        else out.push_back(c);
+    }
+    return out;
+}
+
+static std::string BuildJSFXSliderLine(int sliderIndex, const ParameterInfo& p) {
+    const bool stepIsOne = p.isDiscrete() || p.isLabeled();
+
+    std::string line = "slider" + std::to_string(sliderIndex) + ": "
+        + FmtFloat(p.defaultValue) + "<"
+        + FmtFloat(p.minValue) + ","
+        + FmtFloat(p.maxValue);
+
+    if (stepIsOne) line += ",1";
+
+    // Insert labels *inside* the brackets if labeled
+    if (p.isLabeled() && !p.labels.empty()) {
+        line += "{";
+        for (size_t i = 0; i < p.labels.size(); ++i) {
+            if (i) line += ",";
+            line += SanitizeLabel(p.labels[i]);
+        }
+        line += "}";
+    }
+
+    line += "> " + SanitizeForJSFXName(p.name) + "\n";
+    return line;
+}
+
+
 void InsertEventParameterJSFXForSelectedMediaItem() {
     DebugMsg("Starting InsertEventParameterJSFXForSelectedMediaItem...\n");
 
@@ -4433,7 +4518,7 @@ void InsertEventParameterJSFXForSelectedMediaItem() {
 
 
     // Create the "ReaMOD" directory if it doesn't exist
-    std::string effectsPath = std::string(GetResourcePath()) + "/Effects/ReaMOD";
+    std::string effectsPath = std::string(GetResourcePath()) + "/Effects/ReaMOD/" + projectName;
     DebugMsg("Effects path: %s\n", effectsPath.c_str());
 
     if (!DirectoryExists(effectsPath.c_str())) {
@@ -4450,15 +4535,16 @@ void InsertEventParameterJSFXForSelectedMediaItem() {
 
     // Build JSFX content from FMOD parameters with sequential slider indices
     std::string jsfxContent = "desc: " + jsfxName + "\n";
-    int sliderIndex = 1;  // Start slider indices from 1
+    int sliderIndex = 1;
     for (const auto& param : selectedEventParameters) {
-        jsfxContent += "slider" + std::to_string(sliderIndex++) + ": " +
-                       std::to_string(param.defaultValue) + "<" +
-                       std::to_string(param.minValue) + "," +
-                       std::to_string(param.maxValue) + "> " + param.name + "\n";
-        DebugMsg("Added parameter to JSFX: %s (default: %f, min: %f, max: %f)\n", param.name.c_str(), param.defaultValue, param.minValue, param.maxValue);
+        jsfxContent += BuildJSFXSliderLine(sliderIndex++, param);
+        DebugMsg("Added parameter to JSFX: %s (def:%s, min:%s, max:%s, flags:0x%X)\n",
+            param.name.c_str(),
+            FmtFloat(param.defaultValue).c_str(),
+            FmtFloat(param.minValue).c_str(),
+            FmtFloat(param.maxValue).c_str(),
+            param.flags);
     }
-    jsfxContent += "@sample\n";
 
     // Write the JSFX content to the file
     DebugMsg("Writing JSFX content to file...\n");
@@ -4539,10 +4625,10 @@ static bool commandHook(KbdSectionInfo *sec, const int command, const int val, c
         PlayStopCurrentSelectedEvent();
         return true;
     }
-    // if (command == actionIDInsertParamEnvelopesForSelectedEventOnSelectedItem) {
-    //     InsertEventParameterJSFXForSelectedMediaItem();
-    //     return true;
-    // }
+    if (command == actionIDInsertParamEnvelopesForSelectedEventOnSelectedItem) {
+        InsertEventParameterJSFXForSelectedMediaItem();
+        return true;
+    }
     // if (command == actionIDToggleDebugOnOff) {
     //     toggleDebugMessagesOnOff();
     //     return true;
@@ -4603,8 +4689,8 @@ void RegisterActions() {
     static custom_action_register_t actionTriggerSelectedEvent = { 0, "ReaMOD_TriggerSelectedEvent", "ReaMOD: Play/Stop Current Selected Event" };
     actionIDTriggerSelectedEvent = plugin_register("custom_action", &actionTriggerSelectedEvent);
 
-    // static custom_action_register_t actionInsertParamEnvelopesForSelectedEventOnSelectedItem = { 0, "ReaMOD_InsertParamEnvelopesForSelectedEventOnSelectedItem", "ReaMOD: Insert parameter envelopes for selected FMOD event on selected media item" };
-    // actionIDInsertParamEnvelopesForSelectedEventOnSelectedItem = plugin_register("custom_action", &actionInsertParamEnvelopesForSelectedEventOnSelectedItem);
+    static custom_action_register_t actionInsertParamEnvelopesForSelectedEventOnSelectedItem = { 0, "ReaMOD_InsertParamEnvelopesForSelectedEventOnSelectedItem", "ReaMOD: Insert parameter envelopes for selected FMOD event on selected media item" };
+    actionIDInsertParamEnvelopesForSelectedEventOnSelectedItem = plugin_register("custom_action", &actionInsertParamEnvelopesForSelectedEventOnSelectedItem);
 
     // static custom_action_register_t actionToggleDebugOnOff = { 0, "ReaMOD_ToggleDebugMessagesOnOff", "ReaMOD: Toggle posting debug messages on/off." };
     // actionIDToggleDebugOnOff = plugin_register("custom_action", &actionToggleDebugOnOff);

--- a/src/ReaMOD.cpp
+++ b/src/ReaMOD.cpp
@@ -54,6 +54,7 @@ static int actionIDInsertParamUpdateItemForSelectedMediaItem = 0;
 static int actionIDInsertParamAutomationItemsForSelectedMediaItem = 0;
 static int actionIDInsertPositionInterpolationItemsForSelectedMediaItem = 0;
 static int actionIDInsertParamEnvelopesForSelectedEventOnSelectedItem = 0;
+static int actionIDInsertGlobalParametersJSFX = 0;
 // static int actionIDPostFmodTracksListToConsole = 0;
 static int actionIDSearchForFmodEvent = 0;
 static int actionIDTriggerSelectedEvent = 0;
@@ -150,7 +151,15 @@ struct GlobalParameter {
     float currentValue;
     float minValue;
     float maxValue;
+
+    // NEW:
+    unsigned int flags = 0;                  // FMOD_STUDIO_PARAMETER_FLAGS
+    std::vector<std::string> labels;         // for labeled params
+
+    bool isDiscrete() const { return (flags & FMOD_STUDIO_PARAMETER_DISCRETE) != 0; }
+    bool isLabeled()  const { return (flags & FMOD_STUDIO_PARAMETER_LABELED)  != 0; }
 };
+
 
 // Declare a global vector to store parameters of the selected event
 std::vector<ParameterInfo> selectedEventParameters;
@@ -224,7 +233,8 @@ void LoadReaperAPIFunctions(reaper_plugin_info_t* rec) {
         CountTrackEnvelopes = reinterpret_cast<decltype(CountTrackEnvelopes)>(rec->GetFunc("CountTrackEnvelopes"));
         GetTrackEnvelopeByName = reinterpret_cast<decltype(GetTrackEnvelopeByName)>(rec->GetFunc("GetTrackEnvelopeByName"));
         GetEnvelopeName = reinterpret_cast<decltype(GetEnvelopeName)>(rec->GetFunc("GetEnvelopeName"));
-
+        GetSetMediaTrackInfo_String = reinterpret_cast<decltype(GetSetMediaTrackInfo_String)>(rec->GetFunc("GetSetMediaTrackInfo_String"));
+        InsertTrackAtIndex         = reinterpret_cast<decltype(InsertTrackAtIndex)>(rec->GetFunc("InsertTrackAtIndex"));
     }
 }
 
@@ -426,6 +436,28 @@ void RetrieveGlobalParameters() {
         if (result == FMOD_OK) {
             globalParam.currentValue = currentValue;
         }
+
+        globalParam.flags = paramDesc.flags;
+        
+        // If labeled, pull label strings for each integer index in range
+        if ((globalParam.flags & FMOD_STUDIO_PARAMETER_LABELED) != 0) {
+            const int first = (int)std::round(globalParam.minValue);
+            const int last  = (int)std::round(globalParam.maxValue);
+            for (int li = first; li <= last; ++li) {
+                char buf[256] = {};
+                int retrieved = 0;
+        
+                // Use the System-level label getter for globals (ID is available on paramDesc)
+                FMOD_RESULT lr = fmod_system->getParameterLabelByID(paramDesc.id, li - first, buf, sizeof(buf), &retrieved);
+        
+                if (lr == FMOD_OK && buf[0] != '\0') {
+                    globalParam.labels.emplace_back(buf);
+                } else {
+                    globalParam.labels.emplace_back(std::to_string(li));
+                }
+            }
+        }
+
 
         // Extract prefix from parameter name
         std::string paramName = paramDesc.name;
@@ -4458,6 +4490,29 @@ static std::string BuildJSFXSliderLine(int sliderIndex, const ParameterInfo& p) 
     return line;
 }
 
+static std::string BuildJSFXSliderLine_Global(int sliderIndex, const GlobalParameter& p) {
+    const bool stepIsOne = p.isDiscrete() || p.isLabeled();
+
+    std::string line = "slider" + std::to_string(sliderIndex) + ": "
+        + FmtFloat(p.currentValue) + "<"
+        + FmtFloat(p.minValue) + ","
+        + FmtFloat(p.maxValue);
+
+    if (stepIsOne) line += ",1";
+
+    if (p.isLabeled() && !p.labels.empty()) {
+        line += "{";
+        for (size_t i = 0; i < p.labels.size(); ++i) {
+            if (i) line += ",";
+            line += SanitizeLabel(p.labels[i]);
+        }
+        line += "}";
+    }
+
+    line += "> " + SanitizeForJSFXName(p.name) + "\n";
+    return line;
+}
+
 
 void InsertEventParameterJSFXForSelectedMediaItem() {
     DebugMsg("Starting InsertEventParameterJSFXForSelectedMediaItem...\n");
@@ -4570,6 +4625,138 @@ void InsertEventParameterJSFXForSelectedMediaItem() {
     }
 }
 
+static MediaTrack* FindOrCreateAndSelectGlobalTrack() {
+    const char* TARGET = "FMOD - Global Parameters";
+
+    // Search for an existing track with the exact name
+    const int trackCount = CountTracks(nullptr);
+    for (int i = 0; i < trackCount; ++i) {
+        MediaTrack* tr = GetTrack(nullptr, i);
+        char nameBuf[512] = {};
+        if (GetSetMediaTrackInfo_String &&
+            GetSetMediaTrackInfo_String(tr, "P_NAME", nameBuf, false) &&
+            std::strcmp(nameBuf, TARGET) == 0) {
+
+            // Deselect all tracks
+            for (int j = 0; j < trackCount; ++j) {
+                MediaTrack* tj = GetTrack(nullptr, j);
+                int sel0 = 0;
+                GetSetMediaTrackInfo(tj, "I_SELECTED", &sel0);
+            }
+            // Select just this one
+            { int sel1 = 1; GetSetMediaTrackInfo(tr, "I_SELECTED", &sel1); }
+            UpdateArrange();
+            return tr;
+        }
+    }
+
+    // Not found → create a new track at the end
+    int newIndex = trackCount;
+    if (!InsertTrackAtIndex) {
+        DebugMsg("InsertTrackAtIndex not available.\n");
+        return nullptr;
+    }
+    InsertTrackAtIndex(newIndex, true); // wantDefaults = true
+    UpdateArrange(); // ensure track list updates
+
+    MediaTrack* newTrack = GetTrack(nullptr, newIndex);
+    if (!newTrack) {
+        DebugMsg("Failed to get newly created track.\n");
+        return nullptr;
+    }
+
+    // Name the track
+    if (GetSetMediaTrackInfo_String) {
+        GetSetMediaTrackInfo_String(newTrack, "P_NAME",
+                                    const_cast<char*>("FMOD - Global Parameters"), true);
+    }
+
+    // Deselect all tracks, then select just this one
+    const int total = CountTracks(nullptr);
+    for (int j = 0; j < total; ++j) {
+        MediaTrack* tj = GetTrack(nullptr, j);
+        int sel0 = 0;
+        GetSetMediaTrackInfo(tj, "I_SELECTED", &sel0);
+    }
+    { int sel1 = 1; GetSetMediaTrackInfo(newTrack, "I_SELECTED", &sel1); }
+    UpdateArrange();
+
+    return newTrack;
+}
+
+
+void InsertGlobalParametersJSFXOnSelectedTrack() {
+    // Ensure we have globals for the current project/session
+    if (loaded_banks.empty() || !fmod_system) {
+        PostMsg("FMOD is not initialized or no banks are loaded.\n");
+        return;
+    }
+
+    // (Re)build the list to be safe
+    RetrieveGlobalParameters();  // populates globalParameters
+    if (globalParameters.empty()) {
+        PostMsg("No Global Parameters found.\n");
+        return;
+    }
+
+    // Find or create the "FMOD - Global Parameters" track, select only it
+    MediaTrack* targetTrack = FindOrCreateAndSelectGlobalTrack();
+    if (!targetTrack) {
+        PostMsg("Could not create/select 'FMOD - Global Parameters' track.\n");
+        return;
+    }
+
+    // Build a stable JSFX name: "<Project> - GlobalParameters"
+    std::string projectName = selected_file_name; // e.g., "MyProject.fspro"
+    auto dot = projectName.rfind(".fspro");
+    if (dot != std::string::npos) projectName.erase(dot);
+    std::string jsfxName = projectName + " - GlobalParameters";
+
+    // Create Effects/ReaMOD/<Project> directory if needed
+    std::string effectsPath = std::string(GetResourcePath()) + "/Effects/ReaMOD/" + projectName;
+    if (!fs::exists(effectsPath)) {
+        std::error_code ec;
+        fs::create_directories(effectsPath, ec);
+        if (ec) {
+            DebugMsg("Failed to create Effects/ReaMOD subdir: %s\n", ec.message().c_str());
+            return;
+        }
+    }
+
+    // Write the JSFX file
+    std::string jsfxFilePath = effectsPath + "/" + jsfxName + ".jsfx";
+
+    std::string jsfxContent = "desc: " + jsfxName + "\n";
+    int sliderIndex = 1;
+    for (const auto& gp : globalParameters) {
+        jsfxContent += BuildJSFXSliderLine_Global(sliderIndex++, gp);
+        DebugMsg("Global slider: %s (cur:%f min:%f max:%f flags:0x%X)\n",
+                 gp.name.c_str(), gp.currentValue, gp.minValue, gp.maxValue, gp.flags);
+    }
+    jsfxContent += "@sample\n";
+
+    {
+        std::ofstream f(jsfxFilePath, std::ios::binary);
+        if (!f) {
+            DebugMsg("Failed to create JSFX: %s\n", jsfxFilePath.c_str());
+            return;
+        }
+        f.write(jsfxContent.data(), (std::streamsize)jsfxContent.size());
+    }
+
+    // Insert as a **track** FX on the selected "FMOD - Global Parameters" track
+    int fxIndex = TrackFX_AddByName(targetTrack, jsfxName.c_str(), false, -1);
+    if (fxIndex >= 0) {
+        DebugMsg("Inserted global JSFX '%s' at track FX index %d\n", jsfxName.c_str(), fxIndex);
+        UpdateArrange();
+    } else {
+        DebugMsg("Failed to insert global JSFX '%s'\n", jsfxName.c_str());
+    }
+
+}
+
+
+
 // Command hook function for Reaper custom action
 static bool commandHook(KbdSectionInfo *sec, const int command, const int val, const int valhw, const int relmode, HWND hwnd) {
     // Check if the action ID matches the registered actions
@@ -4609,6 +4796,11 @@ static bool commandHook(KbdSectionInfo *sec, const int command, const int val, c
         InsertParamAutomationItemsForSelectedMediaItem();
         return true;
     }
+    if (command == actionIDInsertGlobalParametersJSFX) {
+        InsertGlobalParametersJSFXOnSelectedTrack();
+        return 1;
+    }
+
     if (command == actionIDInsertPositionInterpolationItemsForSelectedMediaItem) {
         InsertPositionInterpolationItemsForSelectedMediaItem();
         return true;
@@ -4679,6 +4871,10 @@ void RegisterActions() {
     // Register the custom action for inserting parameter automation items
     static custom_action_register_t actionInsertPositionInterpolationItemsForSelectedMediaItem = {0, "ReaMOD_actionInsertPositionInterpolationItemsForSelectedMediaItem", "ReaMOD: Insert position interpolation items for selected media item over time selection"};
     actionIDInsertPositionInterpolationItemsForSelectedMediaItem = plugin_register("custom_action", &actionInsertPositionInterpolationItemsForSelectedMediaItem);
+
+    // Register the custom action for inserting Global Parameter SFX on selected track
+    static custom_action_register_t actionInsertGlobalParametersJSFX = {0, "ReaMOD_actionInsertGlobalParametersJSFXonSelectedTrack", "ReaMOD: Insert FMOD Global Parameters JSFX on selected track"};
+    actionIDInsertGlobalParametersJSFX = plugin_register("custom_action", &actionInsertGlobalParametersJSFX);
 
     // static custom_action_register_t actionPostFmodTracksListToConsole = { 0, "ReaMOD_PostFmodTracksListToConsole", "ReaMOD: Post current list of FMOD tracks to console" };
     // actionIDPostFmodTracksListToConsole = plugin_register("custom_action", &actionPostFmodTracksListToConsole);


### PR DESCRIPTION
**Changes:**
- Improved action for adding custom JSFX to selected item for automating event parameters
    - JSFX gets created inside a project specific folder inside "Reaper Resources Path/Effects/ReaMOD"
    - Sliders now match parameters range, step size, and apply labels for labeled params
- Added new action for inserting a "FMOD - Global Parameters" track with custom JSFX for automating global FMOD parameters